### PR TITLE
Fix Spelling, Capitalization, and Section Numbering in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open [`protocols.json`](./whitelist/protocols.json) and add a new protocol entry
 
 ### 2. Example Protocol Entry
 
-A new protocol entry needs atleast a name, slug and its contract addresses. Optionally, add twitter and logo reference. Logo must be stored under `/img`.
+A new protocol entry needs at least a name, slug and its contract addresses. Optionally, add Twitter and logo reference. Logo must be stored under `/img`.
 
 ```json
 {
@@ -25,6 +25,6 @@ A new protocol entry needs atleast a name, slug and its contract addresses. Opti
 
 Create a pull request (PR) on GitHub to merge your changes into the main branch. Provide a clear description of the changes and the protocol added.
 
-### 6. Review and Merge
+### 4. Review and Merge
 
 Wait for the PR to be reviewed by the maintainers. Once approved, your changes will be merged, and the new protocol will be added to the whitelist.


### PR DESCRIPTION
### 1. Corrected the spelling error "atleast" to "at least".  

> The word "atleast" was used in the documentation, which is not a valid English word.

### 2. Fixed the capitalization of "Twitter".  

> The change to "Twitter" aligns the text with standard capitalization rules for proper nouns.

### 3. Adjusted the section numbering, changing "6. Review and Merge" to "4. Review and Merge".  

> The numbering of sections in the document was inconsistent, jumping from section 3 to section 6, skipping 4 and 5.
> This adjustment ensures a logical and sequential flow, making the document easier to navigate.